### PR TITLE
Add multiple middlewares support

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -96,6 +96,36 @@ app.listen(3000);
 console.log('listening on port 3000');
 ```
 
+You can also mount multiple middlewares if needed. It can be useful
+when you want to have an endpoint secured with the same app instance.
+
+```js
+var mount = require('koa-mount');
+var Koa = require('koa');
+
+async function isAuthed(ctx, next){
+  // apply logic here
+}
+
+async function hello(ctx, next){
+  await next();
+  ctx.body = 'Hello';
+}
+
+async function world(ctx, next){
+  await next();
+  ctx.body = '*Secured* World';
+}
+
+var app = new Koa();
+
+app.use(mount('/hello', hello));
+app.use(mount('/secured', [isAuthed, world]));
+
+app.listen(3000);
+console.log('listening on port 3000');
+```
+
 ### Optional Paths
 
   The path argument is optional, defaulting to "/":

--- a/index.js
+++ b/index.js
@@ -24,7 +24,11 @@ module.exports = mount;
  * @api public
  */
 
-function mount(prefix, app) {
+function mount(prefix, _app) {
+  var app = Array.isArray(_app)
+    ? compose(_app)
+    : _app;
+
   if ('string' != typeof prefix) {
     app = prefix;
     prefix = '/';


### PR DESCRIPTION
This resolves #15 

In some projects I need to secure some assets and I had to create a new koa instance. That's worked but I find it easier to allow to pass multiple middlewares instead of one.

Tests supplied and documentation updated.
As I work with koa@2 I did not updated the code for the stable release but it could be easily done if requested by somebody else.