### PR TITLE
Restore path also when downstream throws

### DIFF
--- a/index.js
+++ b/index.js
@@ -55,14 +55,16 @@ function mount (prefix, app) {
     ctx.path = newPath
     debug('enter %s -> %s', prev, ctx.path)
 
-    await downstream(ctx, async () => {
+    try {
+      await downstream(ctx, async () => {
+        ctx.path = prev
+        await upstream()
+        ctx.path = newPath
+      })
+    } finally {
+      debug('leave %s -> %s', prev, ctx.path)
       ctx.path = prev
-      await upstream()
-      ctx.path = newPath
-    })
-
-    debug('leave %s -> %s', prev, ctx.path)
-    ctx.path = prev
+    }
   }
 
   /**


### PR DESCRIPTION
If the path is not restored on throw, then the upstream middlewares work with a wrong path. This will make metrics and logging etc. to show a wrong path for requests that fail.

## Checklist

- [x] I have ensured my pull request is not behind the main or master branch of the original repository.
- [x] I have rebased all commits where necessary so that reviewing this pull request can be done without having to merge it first.
- [x] I have written a commit message that passes commitlint linting.
- [x] I have ensured that my code changes pass linting tests.
- [x] I have ensured that my code changes pass unit tests.
- [x] I have described my pull request and the reasons for code changes along with context if necessary.
